### PR TITLE
Cleanup package.json and geotiff-contour example usage description

### DIFF
--- a/examples/geotiff-contour.js
+++ b/examples/geotiff-contour.js
@@ -1,7 +1,7 @@
 //
 // Generate GeoJSON contours from a GeoTIFF DEM file
 //
-// usage: `node examples/geojson-contour.js in.tiff 10 out.geo.json`
+// usage: `node examples/geotiff-contour.js in.tiff 10 out.geo.json`
 // (assumes that the input file is in WGS84 for GeoJSON; coordinates are transferred directly)
 //
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/3drobotics/quadtree-contours.git"
+  },
   "author": "Kevin Mehall <km@kevinmehall.net>",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
The package.json file is missing a repository property. This would throw some warning text when running `npm install`.

Also, the geotiff-contour.js example's usage comment was using a different file name. Changed that just to provide a valid usage description.