### PR TITLE
generate contour lines for vertically oblong geotiffs

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class ContourMipmap {
     // Bottom mipmap layer is just the raster: at each pixel the minimum and maximum are the same
     this.levels = [{ min: raster, max: raster, width, height, scale: 1 }];
 
-    while (this.levels[0].width > 1) {
+    while (this.levels[0].width > 1 || this.levels[0].height > 1) {
       this.levels.unshift(mipmapReduce(this.levels[0]));
     }
   }


### PR DESCRIPTION
#### Problem

Geotiffs with features that are much taller than they are wide would not generate contours for the entire height of the geotiff. 

#### Solution

Thanks to @gpbmike, this change managed to get things working. Instead of just checking the width of the particular level before running mipmapReduce on it, check the height as well. 