### PR TITLE
Filter out smaller lines before smoothing

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ class ContourMipmap {
 
     // Closed rings and any unclosed line strings
     return [...rings, ...fragmentStart.values()]
-      .filter(l => l.length >= minPoints)
+      .filter(l => l.length >= minPoints && l.length >= smoothKernelWidth * 2)
       .map(l => smooth(l, smoothOpts))
   }
 }
@@ -290,8 +290,6 @@ function smooth(line, { kernelWidth = 2, cycles = 2 }) {
   }
 
   const sc = 1.0 / (kernelWidth * 2);
-
-  if (line.length < kernelWidth * 2) return [];
 
   for (let cycle = 0; cycle < cycles; cycle++) {
     let px = 0;


### PR DESCRIPTION
#### Problem

When smoothing, lines with less vertices than twice the kernel width were getting returned as an empty array. The empty array isn't required, and can cause problems downstream.

#### Solution

Filter out the lines before smoothing, during the filter that removes any lines with less vertices than the `minPoints` value.

There is another possible solution, where we leave the smooth function as is, and do an additional filter after this line https://github.com/3drobotics/quadtree-contours/commit/1509c06f59c9605626aa76d07a413912a43676b3#diff-168726dbe96b3ce427e7fedce31bb0bcR272
Here, we would just remove any empty array.

I went with this initial approach in this PR because I felt it would be more performant. If we want to leave the smooth function unmodified, we can just add the additional filter as described.
